### PR TITLE
Default prefix argument to empty string

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 /* ACTION TYPER */
 
-module.exports = actionTyper = (prefix) => {
+module.exports = actionTyper = (prefix = '') => {
     return new Proxy({}, {
         get(target, name) {
             return `${prefix}${name}`


### PR DESCRIPTION
This allows `const { alpha } = actionTyper()` to give `alpha === 'alpha'`, rather than `alpha === 'undefinedalpha'`. Useful for global actions, or actions where no prefix is provided.